### PR TITLE
Fix: Copilot agent test comment

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+// Copilot coding agent test - safe to remove
 import 'dart:async'; // NEW: For runZonedGuarded (error handling to MCP)
 
 // Flutter imports:


### PR DESCRIPTION
Adds the requested one-line comment to the top of lib/main.dart.\n\nFixes #14